### PR TITLE
Refactor Random Key Method in EnigmaShift class

### DIFF
--- a/lib/algorithm.rb
+++ b/lib/algorithm.rb
@@ -10,21 +10,20 @@ class Algorithm
     @message = message
     @enigma_key = enigma_key
     @date = date 
-    @character_set = ('a'..'z').to_a << ' '
   end
 
-  def shift_forward(message, enigma_key, date)
-    ## maybe module?
+  def self.shift_forward(message, enigma_key, date)
     enigma_shift = EnigmaShift.new(enigma_key, date)
     enigma_shift.create_shifts(enigma_key, date)
     shifts = enigma_shift.shifts
+    character_set = ('a'..'z').to_a << ' '
     encrypted_string = ''
     downcased_string = message.downcase
 
     downcased_string.each_char.with_index do |char, index|
-      if @character_set.include?(char)
+      if character_set.include?(char)
         shifted_char_index = shifts[index % 4]
-        new_index = (@character_set.index(char) + shifted_char_index) % character_set.length
+        new_index = (character_set.index(char) + shifted_char_index) % character_set.length
         encrypted_string << character_set[new_index]
       else 
         encrypted_string << char
@@ -33,17 +32,18 @@ class Algorithm
     encrypted_string
   end
 
-  def shift_backward(encrypted_string, enigma_key, date)
+  def self.shift_backward(encrypted_string, enigma_key, date)
     enigma_shift = EnigmaShift.new(enigma_key, date)
     enigma_shift.create_shifts(enigma_key, date)
     shifts = enigma_shift.shifts
+    character_set = ('a'..'z').to_a << ' '
     original_message = ''
     
     encrypted_string.each_char.with_index do |char, index|
       if character_set.include?(char)
         shifted_char_index = shifts[index % 4]
-        new_index= (@character_set.index(char) - shifted_char_index) % character_set.length
-        original_message << @character_set[new_index]
+        new_index= (character_set.index(char) - shifted_char_index) % character_set.length
+        original_message << character_set[new_index]
       else
         original_message << char
       end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -6,12 +6,12 @@ class Enigma
               :date
 
   def initialize
-    @message = message 
+    @message = message
   end
 
-  def encrypt(message, enigma_key = '', date = Date.today.strftime('%d/%m/%y') )
-    algorithm = Algorithm.new(message, enigma_key, date) 
-    ciphertext = algorithm.shift_forward(message, enigma_key, date) #class method?
+  def encrypt(message, enigma_key = '', date = Date.today.strftime('%d/%m/%y'))
+    enigma_key = EnigmaShift.generate_random_key_number if enigma_key == ''
+    ciphertext = Algorithm.shift_forward(message, enigma_key, date) #class method?
 
     encrpyted = {
       :encryption => ciphertext,
@@ -21,8 +21,8 @@ class Enigma
   end
 
   def decrypt(ciphertext, enigma_key = '', date = Date.today.strftime('%d/%m/%y'))
-    algorithm = Algorithm.new(ciphertext, enigma_key, date) 
-    original_message = algorithm.shift_backward(ciphertext, enigma_key, date) #class method?
+    enigma_key = EnigmaShift.generate_random_key_number if enigma_key == ''
+    original_message = Algorithm.shift_backward(ciphertext, enigma_key, date) #class method?
     decrpyted = {
       :decryption => original_message,
       :key        => enigma_key,

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -10,7 +10,7 @@ class Enigma
   end
 
   def encrypt(message, enigma_key = '', date = Date.today.strftime('%d/%m/%y'))
-    enigma_key = EnigmaShift.generate_random_key_number if enigma_key == ''
+    enigma_key = EnigmaShift.random_key if enigma_key == ''
     ciphertext = Algorithm.shift_forward(message, enigma_key, date) #class method?
 
     encrpyted = {
@@ -21,7 +21,7 @@ class Enigma
   end
 
   def decrypt(ciphertext, enigma_key = '', date = Date.today.strftime('%d/%m/%y'))
-    enigma_key = EnigmaShift.generate_random_key_number if enigma_key == ''
+    enigma_key = EnigmaShift.random_key if enigma_key == ''
     original_message = Algorithm.shift_backward(ciphertext, enigma_key, date) #class method?
     decrpyted = {
       :decryption => original_message,

--- a/lib/enigma_shift.rb
+++ b/lib/enigma_shift.rb
@@ -17,9 +17,6 @@ class EnigmaShift
   end
 
   def generate_enigma_keys(enigma_key)
-    if enigma_key == ''
-      enigma_key = generate_random_key_number   
-    end
     pairs = convert_to_pairs(enigma_key)
     enigma_keys = { :A => nil, :B => nil, :C => nil, :D => nil }
     i = 0
@@ -30,7 +27,7 @@ class EnigmaShift
     enigma_keys
   end
 
-  def generate_random_key_number
+  def self.generate_random_key_number
     numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     new_key = numbers.sample(5)
     new_key.join 

--- a/lib/enigma_shift.rb
+++ b/lib/enigma_shift.rb
@@ -27,7 +27,7 @@ class EnigmaShift
     enigma_keys
   end
 
-  def self.generate_random_key_number
+  def self.random_key
     numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     new_key = numbers.sample(5)
     new_key.join 

--- a/spec/algorithm_spec.rb
+++ b/spec/algorithm_spec.rb
@@ -13,14 +13,10 @@ describe Algorithm do
     xit 'has default attributes' do
       allow(Date).to receive(:today).and_return(Date.new(2020, 8, 27))
       algorithm = Algorithm.new('Hello World')
-      expected = ["a", "b", "c", "d", "e", "f", "g", "h", "i", 
-                  "j", "k", "l", "m", "n", "o", "p", "q", "r", 
-                  "s", "t", "u", "v", "w", "x", "y", "z", " "]
-
+ 
       expect(algorithm.message).to eq 'Hello World'
       expect(algorithm.enigma_key).to eq ''
       expect(algorithm.date).to eq '27/08/20'
-      expect(algorithm.character_set).to eq expected 
     end
 
     it 'has attributes' do
@@ -32,26 +28,13 @@ describe Algorithm do
     end
   end
 
-  describe '#character_set' do
-    xit 'creates character set' do
-      algorithm = Algorithm.new('Hello World')
-      expected = ["a", "b", "c", "d", "e", "f", "g", "h", "i", 
-                  "j", "k", "l", "m", "n", "o", "p", "q", "r", 
-                  "s", "t", "u", "v", "w", "x", "y", "z", " "]
-
-      expect(algorithm.character_set).to eq expected 
-    end
-  end
-
   describe '#shift_forward' do
     it 'shifts letters forward' do
-      # algorithm = Algorithm.new('Hello World', '02715', '040895')
 
       expect(Algorithm.shift_forward('Hello World', '02715', '040895')).to eq 'keder ohulw'
     end
 
     it 'encyrpts character as itself if character not in chracter set' do
-      # algorithm = Algorithm.new('Hello World!', '02715', '040895')
 
       expect(Algorithm.shift_forward('Hello World!', '02715', '040895')).to eq 'keder ohulw!'
     end
@@ -59,13 +42,11 @@ describe Algorithm do
 
   describe '#shift_backward' do
     it 'shifts letters backward' do
-      # algorithm = Algorithm.new('Hello World', '02715', '040895')
 
       expect(Algorithm.shift_backward('keder ohulw', '02715', '040895')).to eq 'hello world'
     end
 
     it 'decrypts character as itself if character not in chracter set' do
-      # algorithm = Algorithm.new('Hello World', '02715', '040895')
 
       expect(Algorithm.shift_backward('keder ohulw!', '02715', '040895')).to eq 'hello world!'
     end

--- a/spec/algorithm_spec.rb
+++ b/spec/algorithm_spec.rb
@@ -3,14 +3,14 @@ require './lib/algorithm'
 require './lib/enigma_shift'
 
 describe Algorithm do
-  describe '#inistantian' do
+  describe '#initialize' do
     it 'exists' do
       algorithm = Algorithm.new('Hello World', '12345', '27/08/20')
 
       expect(algorithm).is_a? Algorithm 
     end
 
-    it 'has deafult attributes' do
+    xit 'has default attributes' do
       allow(Date).to receive(:today).and_return(Date.new(2020, 8, 27))
       algorithm = Algorithm.new('Hello World')
       expected = ["a", "b", "c", "d", "e", "f", "g", "h", "i", 
@@ -33,7 +33,7 @@ describe Algorithm do
   end
 
   describe '#character_set' do
-    it 'creates character set' do
+    xit 'creates character set' do
       algorithm = Algorithm.new('Hello World')
       expected = ["a", "b", "c", "d", "e", "f", "g", "h", "i", 
                   "j", "k", "l", "m", "n", "o", "p", "q", "r", 
@@ -45,29 +45,29 @@ describe Algorithm do
 
   describe '#shift_forward' do
     it 'shifts letters forward' do
-      algorithm = Algorithm.new('Hello World', '02715', '040895')
+      # algorithm = Algorithm.new('Hello World', '02715', '040895')
 
-      expect(algorithm.shift_forward('Hello World', '02715', '040895')).to eq 'keder ohulw'
+      expect(Algorithm.shift_forward('Hello World', '02715', '040895')).to eq 'keder ohulw'
     end
 
-    it 'returns character as itself if character not in chracter set' do
-      algorithm = Algorithm.new('Hello World!', '02715', '040895')
+    it 'encyrpts character as itself if character not in chracter set' do
+      # algorithm = Algorithm.new('Hello World!', '02715', '040895')
 
-      expect(algorithm.shift_forward('Hello World!', '02715', '040895')).to eq 'keder ohulw!'
+      expect(Algorithm.shift_forward('Hello World!', '02715', '040895')).to eq 'keder ohulw!'
     end
   end
 
   describe '#shift_backward' do
     it 'shifts letters backward' do
-      algorithm = Algorithm.new('Hello World', '02715', '040895')
+      # algorithm = Algorithm.new('Hello World', '02715', '040895')
 
-      expect(algorithm.shift_backward('keder ohulw', '02715', '040895')).to eq 'hello world'
+      expect(Algorithm.shift_backward('keder ohulw', '02715', '040895')).to eq 'hello world'
     end
 
-    it 'returns character as itself if character not in chracter set' do
-      algorithm = Algorithm.new('Hello World', '02715', '040895')
+    it 'decrypts character as itself if character not in chracter set' do
+      # algorithm = Algorithm.new('Hello World', '02715', '040895')
 
-      expect(algorithm.shift_backward('keder ohulw!', '02715', '040895')).to eq 'hello world!'
+      expect(Algorithm.shift_backward('keder ohulw!', '02715', '040895')).to eq 'hello world!'
     end
   end
 end

--- a/spec/enigma_shift_spec.rb
+++ b/spec/enigma_shift_spec.rb
@@ -3,27 +3,20 @@ require 'date'
 require './lib/enigma_shift'
 
 describe EnigmaShift do
-  describe '#instantiation' do
+  describe '#initialize' do
     it 'exists' do
       enigma_shift = EnigmaShift.new
 
       expect(enigma_shift).is_a? EnigmaShift
     end
 
-    it 'has default attributes' do
+    it 'has attributes' do
       allow(Date).to receive(:today).and_return(Date.new(2020, 8, 27))
       enigma_shift = EnigmaShift.new
 
       expect(enigma_shift.enigma_key).to eq ''
-      expect(enigma_shift.date).to eq '27/08/20'
+      expect(enigma_shift.date).to eq ('27/08/20')
       expect(enigma_shift.shifts).to eq ([])
-    end
-
-    it 'has attributes' do
-      enigma_shift = EnigmaShift.new('12345', '27/08/20')
-
-      expect(enigma_shift.enigma_key).to eq '12345'
-      expect(enigma_shift.date).to eq '27/08/20'
     end
   end
 
@@ -33,15 +26,6 @@ describe EnigmaShift do
       expected = {:A => 02, :B => 23, :C => 34, :D => 45}
  
       expect(enigma_shift.generate_enigma_keys('02345')).to eq expected
-    end
-
-    it 'can generate keys with random key numbers' do
-      enigma_shift = EnigmaShift.new
-      enigma_key = ''
-      allow(enigma_shift).to receive(:generate_random_key_number) {'12345'}
-      expected = {:A => 12, :B => 23, :C => 34, :D => 45}
-  
-      expect(enigma_shift.generate_enigma_keys(enigma_key)).to eq expected 
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -45,7 +45,7 @@ describe Enigma do
     it 'encrypts message with only message' do
       allow(Date).to receive(:today).and_return(Date.new(1995, 8, 04))
       enigma = Enigma.new
-      allow(EnigmaShift).to receive(:generate_random_key_number) {'12345'}
+      allow(EnigmaShift).to receive(:random_key) {'12345'}
       expected = {
         :encryption => 'uauha!ekdhm',
         :key        => '12345',

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -3,7 +3,7 @@ require './lib/enigma'
 require './lib/algorithm'
 
 describe Enigma do
-  describe '#instantiation' do
+  describe 'initialize' do
     it 'exists' do
       enigma = Enigma.new
       
@@ -45,13 +45,14 @@ describe Enigma do
     it 'encrypts message with only message' do
       allow(Date).to receive(:today).and_return(Date.new(1995, 8, 04))
       enigma = Enigma.new
+      allow(EnigmaShift).to receive(:generate_random_key_number) {'12345'}
       expected = {
-        :encryption => 'keder ohulw',
-        :key        => '02715',
+        :encryption => 'uauha!ekdhm',
+        :key        => '12345',
         :date       => '040895'
       }
-
-      expect(enigma.encrypt('Hello World', '02715')).to eq expected
+ 
+      expect(enigma.encrypt('Hello!World')).to eq expected
     end
   end
 


### PR DESCRIPTION
Rename `generate_random_key_number` to `self.random_key` method. 
Update `shift_forward` and `shift_backward` methods in Algorithm class to class methods