### PR TITLE
Refactor Enigma_Shift Class 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    docile (1.3.5)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
+
+PLATFORMS
+  arm64-darwin-20
+
+DEPENDENCIES
+  simplecov
+
+BUNDLED WITH
+   2.2.15

--- a/lib/algorithm_helper.rb
+++ b/lib/algorithm_helper.rb
@@ -1,0 +1,56 @@
+class AlogrithmHelper
+  attr_reader :shifts
+
+  def initialize
+    @shifts = []
+  end
+
+  def create_shifts(enigma_key, date)
+    enigma_keys = generate_enigma_keys(enigma_key)
+    offsets = generate_offsets(date)
+    combined = enigma_keys.merge(offsets) { |letter, key, offset|  key + offset } 
+    combined.each { |key, value| @shifts << value }
+  end
+
+  def generate_enigma_keys(enigma_key)
+    pairs = convert_to_pairs(enigma_key)
+    enigma_keys = create_letter_hash
+    assign_to_letter(enigma_keys, pairs)
+    enigma_keys
+  end
+
+  def generate_offsets(date)
+    last_four = convert_date(date)
+    enigma_offsets = create_letter_hash 
+    assign_to_letter(enigma_offsets, last_four)
+    enigma_offsets 
+  end
+
+  def assign_to_letter(letter_hash, digits)
+    i = 0
+    letter_hash.each_with_index do |(letter, value), i|
+      letter_hash[letter] = digits[i].to_i
+      i += 1
+    end
+  end
+
+  def create_letter_hash
+    hash = Hash.new
+    ('A'..'D').each do |letter| 
+      hash[letter.to_sym] = nil
+    end 
+    hash
+  end
+
+  def convert_to_pairs(enigma_key)
+    (0...enigma_key.length - 1).map do |index|
+        enigma_key[index..index + 1]
+    end
+  end
+
+  def convert_date(date)
+    number = date.split('/').join.to_i
+    (number ** 2).to_s[-4..-1]
+  end
+end
+

--- a/lib/enigma_shift.rb
+++ b/lib/enigma_shift.rb
@@ -1,4 +1,4 @@
-class EnigmaShift
+class Alogrithm
   attr_reader :shifts
 
   def initialize
@@ -14,36 +14,38 @@ class EnigmaShift
 
   def generate_enigma_keys(enigma_key)
     pairs = convert_to_pairs(enigma_key)
-    enigma_keys = { :A => nil, :B => nil, :C => nil, :D => nil }
-    i = 0
-    enigma_keys.each do |key, value|
-      enigma_keys[key] = pairs[i].to_i
-      i += 1
-    end
+    enigma_keys = create_letter_hash
+    assign_to_letter(enigma_keys, pairs)
     enigma_keys
   end
 
-  def self.random_key
-    numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    new_key = numbers.sample(5)
-    new_key.join 
+  def generate_offsets(date)
+    last_four = convert_date(date)
+    enigma_offsets = create_letter_hash 
+    assign_to_letter(enigma_offsets, last_four)
+    enigma_offsets 
+  end
+
+  def assign_to_letter(letter_hash, digits)
+    i = 0
+    letter_hash.each_with_index do |(letter, value), i|
+      letter_hash[letter] = digits[i].to_i
+      i += 1
+    end
+  end
+
+  def create_letter_hash
+    hash = Hash.new
+    ('A'..'D').each do |letter| 
+      hash[letter.to_sym] = nil
+    end 
+    hash
   end
 
   def convert_to_pairs(enigma_key)
     (0...enigma_key.length - 1).map do |index|
         enigma_key[index..index + 1]
     end
-  end
-
-  def generate_offsets(date)
-    last_four = convert_date(date)
-    enigma_offsets = { :A => nil, :B => nil, :C => nil, :D => nil }
-    i = 0
-    enigma_offsets.each do |key, value|
-      enigma_offsets[key] = last_four[i].to_i
-      i += 1
-    end
-    enigma_offsets 
   end
 
   def convert_date(date)

--- a/spec/algorithm_helper_spec.rb
+++ b/spec/algorithm_helper_spec.rb
@@ -1,0 +1,84 @@
+require 'rspec'
+require 'date'
+require './lib/algorithm_helper'
+
+describe AlgorithmHelper do
+  describe '#initialize' do
+    it 'exists' do
+      algorithm_helper = AlgorithmHelper.new
+
+      expect(algorithm_helper).is_a? EnigmaShift
+    end
+
+    it 'has attributes' do
+      algorithm_helper = AlgorithmHelper.new
+
+      expect(algorithm_helper.shifts).to eq ([])
+    end
+  end
+
+  describe '#generate_enigma_keys' do
+    it 'can generate keys wtih enigma key' do
+      algorithm_helper = AlgorithmHelper.new
+      expected = {:A => 02, :B => 23, :C => 34, :D => 45}
+ 
+      expect(algorithm_helper.generate_enigma_keys('02345')).to eq expected
+    end
+  end
+
+  describe '#convert_to_pairs' do
+    it 'converts enigma key to digit pairs ' do
+      algorithm_helper = AlgorithmHelper.new
+      expected = ['12', '23', '34', '45']
+
+      expect(algorithm_helper.convert_to_pairs('12345')).to eq expected
+    end
+  end
+
+  describe '#generate_offsets' do
+    it 'generates offset from date' do
+      algorithm_helper = AlgorithmHelper.new
+      expected = { :A => 2, :B => 4, :C => 0, :D => 0 }
+
+      expect(algorithm_helper.generate_offsets('270820')).to eq expected
+    end 
+  end
+
+  describe '#convert_date' do
+    it 'converts date into digits' do
+      algorithm_helper = AlgorithmHelper.new
+  
+      expect(algorithm_helper.convert_date('270820')).to eq '2400'
+    end
+  end
+
+  describe '#create_shifts' do
+    it 'assign sum of key and offset to shift' do
+      algorithm_helper = AlgorithmHelper.new
+  t(algorithm_helper.create_shifts('12345', '270820')
+      expected = [14, 27, 34, 45]
+
+      expect(algorithm_helper.shifts).to eq expected 
+    end
+  end
+
+  describe '#create_letter_hash' do
+    it 'creates hash with letters as keys' do
+      algorithm_helper = AlgorithmHelper.new
+      expected = { :A => nil, :B => nil, :C => nil, :D => nil}
+      
+      expect(algorithm_helper.create_letter_hash).to eq expected 
+    end
+  end
+
+  describe '#assign_to_letter' do
+    it 'Assigns digits as values to letters keys' do
+      algorithm_helper = AlgorithmHelper.new
+      letter_hash = { :A => nil, :B => nil, :C => nil, :D => nil}
+      digits = [12, 13 , 14, 15]
+      expected = { :A => 12, :B => 13, :C => 14, :D => 15}
+    
+      expect(algorithm_helper.assign_to_letter(letter_hash, digits)).to eq expected 
+    end
+  end
+end 

--- a/spec/enigma_shift_spec.rb
+++ b/spec/enigma_shift_spec.rb
@@ -37,6 +37,7 @@ describe EnigmaShift do
 
   describe '#generate_offsets' do
     it 'generates offset from date' do
+      enigma_shift = EnigmaShift.new
       expected = { :A => 2, :B => 4, :C => 0, :D => 0 }
 
       expect(enigma_shift.generate_offsets('270820')).to eq expected
@@ -53,10 +54,31 @@ describe EnigmaShift do
 
   describe '#create_shifts' do
     it 'assign sum of key and offset to shift' do
+      enigma_shift = EnigmaShift.new
       enigma_shift.create_shifts('12345', '270820')
       expected = [14, 27, 34, 45]
 
       expect(enigma_shift.shifts).to eq expected 
+    end
+  end
+
+  describe '#create_letter_hash' do
+    it 'creates hash with letters as keys' do
+      enigma_shift = EnigmaShift.new
+      expected = { :A => nil, :B => nil, :C => nil, :D => nil}
+      
+      expect(enigma_shift.create_letter_hash).to eq expected 
+    end
+  end
+
+  describe '#assign_to_letter' do
+    it 'Assigns digits as values to letters keys' do
+      enigma_shift = EnigmaShift.new
+      letter_hash = { :A => nil, :B => nil, :C => nil, :D => nil}
+      digits = [12, 13 , 14, 15]
+      expected = { :A => 12, :B => 13, :C => 14, :D => 15}
+    
+      expect(enigma_shift.assign_to_letter(letter_hash, digits)).to eq expected 
     end
   end
 end 


### PR DESCRIPTION
Rename EnigmaShift class to AlgorithmHelper class.
Migrate `random_key` method to Enigma class.
Create helper methods: 
- assign_to_letter: assign digit as value to each letter key
- create_letter_hash: creates a hash 
- convert_to_pairs: convert the 
- convert_date: takes the default date or date.Today into a string 
Edit tests to reflect changes
